### PR TITLE
Moved saving of buffer to temp file

### DIFF
--- a/lib/atom-html-preview-view.coffee
+++ b/lib/atom-html-preview-view.coffee
@@ -1,7 +1,6 @@
 fs                    = require 'fs'
 {CompositeDisposable, Disposable} = require 'atom'
 {$, $$$, ScrollView}  = require 'atom-space-pen-views'
-_                     = require 'underscore-plus'
 path                  = require 'path'
 os                    = require 'os'
 
@@ -83,10 +82,10 @@ class AtomHtmlPreviewView extends ScrollView
     @editorSub = new CompositeDisposable
 
     if @editor?
-      if not atom.config.get("atom-html-preview.triggerOnSave")
-        @editorSub.add @editor.onDidChange _.debounce(changeHandler, 700)
-      else
+      if atom.config.get("atom-html-preview.triggerOnSave")
         @editorSub.add @editor.onDidSave changeHandler
+      else
+        @editorSub.add @editor.onDidStopChanging changeHandler
       @editorSub.add @editor.onDidChangePath => @trigger 'title-changed'
 
   renderHTML: ->
@@ -94,25 +93,25 @@ class AtomHtmlPreviewView extends ScrollView
     if @editor?
       @renderHTMLCode()
 
-  save: ->
+  save: (callback) ->
     # Temp file path
     outPath = path.resolve os.tmpdir() + @editor.getTitle()
     # Add base tag; allow relative links to work despite being loaded
     # as the src of an iframe
     out = "<base href=\"" + @getPath() + "\">" + @editor.getText()
-    fs.writeFileSync outPath, out
     @tmpPath = outPath
+    fs.writeFile outPath, out, callback
 
   renderHTMLCode: (text) ->
-    if not atom.config.get("atom-html-preview.triggerOnSave") and @editor.getPath()? then @save()
-    iframe = document.createElement("iframe")
-    # Fix from @kwaak (https://github.com/webBoxio/atom-html-preview/issues/1/#issuecomment-49639162)
-    # Allows for the use of relative resources (scripts, styles)
-    iframe.setAttribute("sandbox", "allow-scripts allow-same-origin")
-    iframe.src = @tmpPath
-    @html $ iframe
-    # @trigger('atom-html-preview:html-changed')
-    atom.commands.dispatch 'atom-html-preview', 'html-changed'
+    if not atom.config.get("atom-html-preview.triggerOnSave") and @editor.getPath()? then @save () =>
+      iframe = document.createElement("iframe")
+      # Fix from @kwaak (https://github.com/webBoxio/atom-html-preview/issues/1/#issuecomment-49639162)
+      # Allows for the use of relative resources (scripts, styles)
+      iframe.setAttribute("sandbox", "allow-scripts allow-same-origin")
+      iframe.src = @tmpPath
+      @html $ iframe
+      # @trigger('atom-html-preview:html-changed')
+      atom.commands.dispatch 'atom-html-preview', 'html-changed'
 
   getTitle: ->
     if @editor?

--- a/lib/atom-html-preview-view.coffee
+++ b/lib/atom-html-preview-view.coffee
@@ -1,4 +1,5 @@
 path                  = require 'path'
+fs                    = require 'fs'
 {CompositeDisposable, Disposable} = require 'atom'
 {$, $$$, ScrollView}  = require 'atom-space-pen-views'
 _                     = require 'underscore-plus'
@@ -91,13 +92,21 @@ class AtomHtmlPreviewView extends ScrollView
     if @editor?
       @renderHTMLCode()
 
+  save: ->
+    outPath = path.resolve "/tmp/" + @editor.getTitle() + ".tmp"
+    # console.log outPath
+    out = @editor.getText()
+    fs.writeFileSync outPath, out
+    return outPath
+
   renderHTMLCode: (text) ->
-    if not atom.config.get("atom-html-preview.triggerOnSave") and @editor.getPath()? then @editor.save()
+    outPath = @getPath()
+    if not atom.config.get("atom-html-preview.triggerOnSave") and @editor.getPath()? then outPath = @save() # @editor.save()
     iframe = document.createElement("iframe")
     # Fix from @kwaak (https://github.com/webBoxio/atom-html-preview/issues/1/#issuecomment-49639162)
     # Allows for the use of relative resources (scripts, styles)
     iframe.setAttribute("sandbox", "allow-scripts allow-same-origin")
-    iframe.src = @getPath()
+    iframe.src = outPath
     @html $ iframe
     # @trigger('atom-html-preview:html-changed')
     atom.commands.dispatch 'atom-html-preview', 'html-changed'

--- a/lib/atom-html-preview-view.coffee
+++ b/lib/atom-html-preview-view.coffee
@@ -1,8 +1,9 @@
-path                  = require 'path'
 fs                    = require 'fs'
 {CompositeDisposable, Disposable} = require 'atom'
 {$, $$$, ScrollView}  = require 'atom-space-pen-views'
 _                     = require 'underscore-plus'
+path                  = require 'path'
+os                    = require 'os'
 
 module.exports =
 class AtomHtmlPreviewView extends ScrollView
@@ -23,6 +24,7 @@ class AtomHtmlPreviewView extends ScrollView
 
     if @editorId?
       @resolveEditor(@editorId)
+      @tmpPath = @getPath() # after resolveEditor
     else
       if atom.workspace?
         @subscribeToFilePath(filePath)
@@ -93,20 +95,21 @@ class AtomHtmlPreviewView extends ScrollView
       @renderHTMLCode()
 
   save: ->
-    outPath = path.resolve "/tmp/" + @editor.getTitle() + ".tmp"
-    # console.log outPath
-    out = @editor.getText()
+    # Temp file path
+    outPath = path.resolve os.tmpdir() + @editor.getTitle()
+    # Add base tag; allow relative links to work despite being loaded
+    # as the src of an iframe
+    out = "<base href=\"" + @getPath() + "\">" + @editor.getText()
     fs.writeFileSync outPath, out
-    return outPath
+    @tmpPath = outPath
 
   renderHTMLCode: (text) ->
-    outPath = @getPath()
-    if not atom.config.get("atom-html-preview.triggerOnSave") and @editor.getPath()? then outPath = @save() # @editor.save()
+    if not atom.config.get("atom-html-preview.triggerOnSave") and @editor.getPath()? then @save()
     iframe = document.createElement("iframe")
     # Fix from @kwaak (https://github.com/webBoxio/atom-html-preview/issues/1/#issuecomment-49639162)
     # Allows for the use of relative resources (scripts, styles)
     iframe.setAttribute("sandbox", "allow-scripts allow-same-origin")
-    iframe.src = outPath
+    iframe.src = @tmpPath
     @html $ iframe
     # @trigger('atom-html-preview:html-changed')
     atom.commands.dispatch 'atom-html-preview', 'html-changed'

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.5",
-    "underscore-plus": "^1.6.6"
+    "atom-space-pen-views": "^2.0.5"
   },
   "readme": "# Atom HTML Preview\n\nA live preview tool for Atom Editor.\n\nInstall:\n```bash\napm install atom-html-preview\n```\n\nToogle HTML Preview:\n\nPress `CTRL-P` in editor to open Preview.\n\n![Atom HTML Preview](https://dl.dropboxusercontent.com/u/20947008/webbox/atom/atom-html-preview.png)\n\nAn example with [Twitter Bootstrap 3 Package][1]\n\n![Atom HTML Preview with Bootstrap](https://dl.dropboxusercontent.com/u/20947008/webbox/atom/atom-bootstrap-3.gif)\n\n[1]: http://atom.io/packages/atom-bootstrap3\n",
   "readmeFilename": "README.md",
@@ -28,52 +27,15 @@
   "_atomModuleCache": {
     "version": 1,
     "dependencies": [
-      {
-        "name": "underscore-plus",
-        "version": "1.6.6",
-        "path": "node_modules/underscore-plus/lib/underscore-plus.js"
-      },
-      {
-        "name": "underscore",
-        "version": "1.6.0",
-        "path": "node_modules/underscore-plus/node_modules/underscore/underscore.js"
-      }
     ],
     "extensions": {
       ".coffee": [
         "lib/atom-html-preview-view.coffee",
         "lib/atom-html-preview.coffee"
       ],
-      ".js": [
-        "node_modules/underscore-plus/lib/underscore-plus.js",
-        "node_modules/underscore-plus/node_modules/underscore/underscore-min.js",
-        "node_modules/underscore-plus/node_modules/underscore/underscore.js"
-      ],
       ".json": [
-        "node_modules/underscore-plus/node_modules/underscore/package.json",
-        "node_modules/underscore-plus/package.json",
         "package.json"
       ]
-    },
-    "folders": [
-      {
-        "paths": [
-          "lib",
-          ""
-        ],
-        "dependencies": {
-          "underscore-plus": "^1.2.1"
-        }
-      },
-      {
-        "paths": [
-          "node_modules/underscore-plus/lib",
-          "node_modules/underscore-plus"
-        ],
-        "dependencies": {
-          "underscore": "~1.6.0"
-        }
-      }
-    ]
+    }
   }
 }


### PR DESCRIPTION
As title says, saves buffer to temp file (os independent thanks to the os package) and uses that file as the `iframe` src. Addresses issues #58 and #64.

Also adds a `<base>` tag to the beginning of the temp file, to allow relative links to work. For example, a `<link>` for a stylesheet still works with the relative path.

Example (note the buffer doesn't save at all):
![atom](https://cloud.githubusercontent.com/assets/1988562/10303219/e02b54e0-6bc6-11e5-8ad4-c0bb75d282db.gif)