### PR TITLE
Implemented reload on change of external resources (#49)

### DIFF
--- a/lib/atom-html-preview-view.coffee
+++ b/lib/atom-html-preview-view.coffee
@@ -39,7 +39,8 @@ class AtomHtmlPreviewView extends ScrollView
 
   destroy: ->
     # @unsubscribe()
-    @editorSub.dispose()
+    if editorSub?
+      @editorSub.dispose()
 
   subscribeToFilePath: (filePath) ->
     @trigger 'title-changed'

--- a/lib/atom-html-preview-view.coffee
+++ b/lib/atom-html-preview-view.coffee
@@ -103,15 +103,15 @@ class AtomHtmlPreviewView extends ScrollView
     fs.writeFile outPath, out, callback
 
   renderHTMLCode: (text) ->
-    if not atom.config.get("atom-html-preview.triggerOnSave") and @editor.getPath()? then @save () =>
-      iframe = document.createElement("iframe")
-      # Fix from @kwaak (https://github.com/webBoxio/atom-html-preview/issues/1/#issuecomment-49639162)
-      # Allows for the use of relative resources (scripts, styles)
-      iframe.setAttribute("sandbox", "allow-scripts allow-same-origin")
-      iframe.src = @tmpPath
-      @html $ iframe
-      # @trigger('atom-html-preview:html-changed')
-      atom.commands.dispatch 'atom-html-preview', 'html-changed'
+    if not atom.config.get("atom-html-preview.triggerOnSave") and @editor.getPath()? then @save()
+    iframe = document.createElement("iframe")
+    # Fix from @kwaak (https://github.com/webBoxio/atom-html-preview/issues/1/#issuecomment-49639162)
+    # Allows for the use of relative resources (scripts, styles)
+    iframe.setAttribute("sandbox", "allow-scripts allow-same-origin")
+    iframe.src = @tmpPath
+    @html $ iframe
+    # @trigger('atom-html-preview:html-changed')
+    atom.commands.dispatch 'atom-html-preview', 'html-changed'
 
   getTitle: ->
     if @editor?

--- a/lib/atom-html-preview.coffee
+++ b/lib/atom-html-preview.coffee
@@ -16,6 +16,13 @@ module.exports =
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     @subscriptions = new CompositeDisposable
 
+    @subscriptions.add atom.workspace.observeTextEditors (editor) =>
+      @subscriptions.add editor.onDidSave =>
+        console.log "onDidSave"
+        console.log htmlPreviewView?
+        if htmlPreviewView? and htmlPreviewView instanceof HtmlPreviewView
+          htmlPreviewView.renderHTML()
+
     # Register command that toggles this view
     @subscriptions.add atom.commands.add 'atom-workspace', 'atom-html-preview:toggle': => @toggle()
 
@@ -33,9 +40,11 @@ module.exports =
         return
 
       if host is 'editor'
-        new HtmlPreviewView(editorId: pathname.substring(1))
+        @htmlPreviewView = new HtmlPreviewView(editorId: pathname.substring(1))
       else
-        new HtmlPreviewView(filePath: pathname)
+        @htmlPreviewView = new HtmlPreviewView(filePath: pathname)
+    
+      return htmlPreviewView
 
   toggle: ->
     editor = atom.workspace.getActiveTextEditor()

--- a/lib/atom-html-preview.coffee
+++ b/lib/atom-html-preview.coffee
@@ -18,8 +18,6 @@ module.exports =
 
     @subscriptions.add atom.workspace.observeTextEditors (editor) =>
       @subscriptions.add editor.onDidSave =>
-        console.log "onDidSave"
-        console.log htmlPreviewView?
         if htmlPreviewView? and htmlPreviewView instanceof HtmlPreviewView
           htmlPreviewView.renderHTML()
 


### PR DESCRIPTION
Implemented a rather simple version of #49:
Everytime _any_ file in Atom is saved the HTML preview is updated.