### PR TITLE
Resizing without pointer-events close #65 close #59

### DIFF
--- a/lib/atom-html-preview-view.coffee
+++ b/lib/atom-html-preview-view.coffee
@@ -32,6 +32,18 @@ class AtomHtmlPreviewView extends ScrollView
         atom.packages.onDidActivatePackage =>
           @subscribeToFilePath(filePath)
 
+    # Disable pointer-events while resizing
+    handles = $("atom-pane-resize-handle")
+    handles.on 'mousedown', => @onStartedResize()
+
+  onStartedResize: ->
+    @css 'pointer-events': 'none'
+    document.addEventListener 'mouseup', @onStoppedResizing.bind this
+
+  onStoppedResizing: ->
+    @css 'pointer-events': 'all'
+    document.removeEventListener 'mouseup', @onStoppedResizing
+
   serialize: ->
     deserializer : 'AtomHtmlPreviewView'
     filePath     : @getPath()


### PR DESCRIPTION
This fix allows resizing without losing focus when the cursor travels over the preview window.

Addresses #65 and #59 