### PR TITLE
Isolated devtools

### DIFF
--- a/lib/atom-html-preview-view.coffee
+++ b/lib/atom-html-preview-view.coffee
@@ -164,8 +164,8 @@ class AtomHtmlPreviewView extends ScrollView
     fs.writeFile outPath, out, =>
       try
         @renderHTMLCode()
-      catch (error)
-        @showError(error)
+      catch error
+        @showError error
 
   renderHTMLCode: () ->
     unless @webview?

--- a/lib/atom-html-preview-view.coffee
+++ b/lib/atom-html-preview-view.coffee
@@ -17,8 +17,9 @@ class AtomHtmlPreviewView extends ScrollView
 
   @content: ->
     @div class: 'atom-html-preview native-key-bindings', tabindex: -1, =>
-      @div class: 'show-error', style: 'z-index: 2; padding: 2em;'
-      @div class: 'show-loading', style: 'z-index: 1; padding: 2em;', "Loading HTML"
+      style = 'z-index: 2; padding: 2em;'
+      @div class: 'show-error', style: style
+      @div class: 'show-loading', style: style, "Loading HTML"
 
   constructor: ({@editorId, filePath}) ->
     super
@@ -161,11 +162,10 @@ class AtomHtmlPreviewView extends ScrollView
 
     @tmpPath = outPath
     fs.writeFile outPath, out, =>
-      try {
+      try
         @renderHTMLCode()
-      } catch (error) {
+      catch (error)
         @showError(error)
-      }
 
   renderHTMLCode: () ->
     unless @webview?

--- a/lib/atom-html-preview-view.coffee
+++ b/lib/atom-html-preview-view.coffee
@@ -32,6 +32,18 @@ class AtomHtmlPreviewView extends ScrollView
         atom.packages.onDidActivatePackage =>
           @subscribeToFilePath(filePath)
 
+    # Disable pointer-events while resizing
+    handles = $("atom-pane-resize-handle")
+    handles.on 'mousedown', => @onStartedResize()
+
+  onStartedResize: ->
+    @css 'pointer-events': 'none'
+    document.addEventListener 'mouseup', @onStoppedResizing.bind this
+
+  onStoppedResizing: ->
+    @css 'pointer-events': 'all'
+    document.removeEventListener 'mouseup', @onStoppedResizing
+
   serialize: ->
     deserializer : 'AtomHtmlPreviewView'
     filePath     : @getPath()

--- a/menus/atom-html-preview.cson
+++ b/menus/atom-html-preview.cson
@@ -2,6 +2,14 @@
   'atom-text-editor': [
     {label: 'Preview HTML', command: 'atom-html-preview:toggle'}
   ]
+  '.atom-html-preview webview': [
+    {label: 'Cut', command: 'core:cut'}
+    {label: 'Copy', command: 'core:copy'}
+    {label: 'Paste', command: 'core:paste'}
+    {label: 'Print', command: 'atom-html-preview:print'}
+    {label: 'Open Devtools', command: 'atom-html-preview:open-devtools'}
+    {label: 'Inspect', command: 'atom-html-preview:inspect'}
+  ]
 
 'menu': [
   {


### PR DESCRIPTION
Use isolated devtools for testing javascript and such!

Closes #92

From here it should be easy to ensure that the [header charset](https://www.w3.org/International/articles/http-charset/index#charset) is set to `utf-8` via [`<webview>.loadUrl({ extraHeaders })` option](http://electron.atom.io/docs/v0.37.2/api/web-view-tag/#webviewloadurlurl-options)